### PR TITLE
/api/scan returns policy JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ install:
 script:
   - golint -set_exit_status ./...
   - go test -v .
+  - go test -v ./policy

--- a/api.go
+++ b/api.go
@@ -97,7 +97,7 @@ func asyncPolicyCheck(api API, domain string) <-chan checker.CheckResult {
 	return result
 }
 
-func defaultCheck(api API, domain string) (string, error) {
+func defaultCheck(api API, domain string) (checker.DomainResult, error) {
 	policyChan := asyncPolicyCheck(api, domain)
 	result := checker.CheckDomain(domain, nil)
 	result.ExtraResults = make(map[string]checker.CheckResult)

--- a/api.go
+++ b/api.go
@@ -89,9 +89,7 @@ func (api API) policyCheck(domain string) checker.CheckResult {
 // is List.
 func asyncPolicyCheck(api API, domain string) <-chan checker.CheckResult {
 	result := make(chan checker.CheckResult)
-	go func(result chan<- checker.CheckResult, api API, domain string) {
-		result <- api.policyCheck(domain)
-	}(result, api, domain)
+	go func() { result <- api.policyCheck(domain) }()
 	return result
 }
 

--- a/api.go
+++ b/api.go
@@ -61,7 +61,7 @@ func apiWrapper(api apiHandler) func(w http.ResponseWriter, r *http.Request) {
 
 func (api API) policyCheck(domain string) checker.CheckResult {
 	result := checker.CheckResult{Name: "policylist"}
-	if _, err := api.List.Get(domain); err != nil {
+	if _, err := api.List.Get(domain); err == nil {
 		return result.Success()
 	}
 	domainData, err := api.Database.GetDomain(domain)

--- a/api.go
+++ b/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/EFForg/starttls-check/checker"
 	"github.com/EFForg/starttls-scanner/db"
+	"github.com/EFForg/starttls-scanner/policy"
 )
 
 ////////////////////////////////
@@ -35,6 +36,7 @@ type checkPerformer func(string) (string, error)
 type API struct {
 	Database    db.Database
 	CheckDomain checkPerformer
+	List        policy.List
 }
 
 func defaultCheck(domain string) (string, error) {

--- a/api.go
+++ b/api.go
@@ -34,7 +34,14 @@ type checkPerformer func(API, string) (string, error)
 type API struct {
 	Database    db.Database
 	CheckDomain checkPerformer
-	List        policy.List
+	List        PolicyList
+}
+
+// PolicyList interface wraps a policy-list like structure.
+// The most important query you can perform is to fetch the policy
+// for a particular domain.
+type PolicyList interface {
+	Get(string) (policy.TLSPolicy, error)
 }
 
 // APIResponse wraps all the responses from this API.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/EFForg/starttls-scanner/db"
+	"github.com/EFForg/starttls-scanner/policy"
 	"github.com/gorilla/handlers"
 )
 
@@ -53,6 +54,7 @@ func main() {
 	api := API{
 		Database:    db,
 		CheckDomain: defaultCheck,
+		List:        policy.CreateUpdatedList(),
 	}
 	ServePublicEndpoints(&api, &cfg)
 }

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	api := API{
 		Database:    db,
 		CheckDomain: defaultCheck,
-		List:        policy.CreateUpdatedList(),
+		List:        policy.MakeUpdatedList(),
 	}
 	ServePublicEndpoints(&api, &cfg)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 // Workflow tests against REST API.
-// TODO: Mock starttls-scanner/check so we don't actually make check requests
 
 var api *API
 

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ import (
 
 var api *API
 
-func mockCheckPerform(message string) func(string) (checker.DomainResult, error) {
+func mockCheckPerform(message string) func(API, string) (checker.DomainResult, error) {
 	return func(api API, domain string) (checker.DomainResult, error) {
 		return checker.DomainResult{Domain: domain, Message: message}, nil
 	}
@@ -359,7 +359,7 @@ func TestScanCached(t *testing.T) {
 	data := url.Values{}
 	data.Set("domain", "eff.org")
 	testRequest("POST", "/api/scan", data, api.Scan)
-	original, _ := api.CheckDomain("eff.org")
+	original, _ := api.CheckDomain(*api, "eff.org")
 	// Perform scan again, with different expected result.
 	api.CheckDomain = mockCheckPerform("somethingelse")
 	resp := testRequest("POST", "/api/scan", data, api.Scan)

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ import (
 
 var api *API
 
-func mockCheckPerform(domain string) (string, error) {
+func mockCheckPerform(api API, domain string) (string, error) {
 	return fmt.Sprintf("{\n\"domain\": \"%s\"\n}", domain), nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ func mockCheckPerform(api API, domain string) (string, error) {
 	return fmt.Sprintf("{\n\"domain\": \"%s\"\n}", domain), nil
 }
 
+// Mock PolicyList
 type mockList struct {
 	domains map[string]bool
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,0 +1,146 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// PolicyURL is the default URL from which to fetch the policy JSON.
+const PolicyURL = "https://dl.eff.org/starttls-everywhere/policy.json"
+
+// Pinset represents a set of valid public keys for a domain's
+// SSL certificate.
+type Pinset struct {
+	StaticSPKIHashes []string `json:"static-spki-hashes"`
+}
+
+// TLSPolicy dictates the policy for a particular email domain.
+type TLSPolicy struct {
+	PolicyAlias   string   `json:"policy-alias,omitempty"`
+	MinTLSVersion string   `json:"min-tls-version,omitempty"`
+	Mode          string   `json:"mode"`
+	MXs           []string `json:"mxs"`
+	Pin           string   `json:"pin,omitempty"`
+	Report        string   `json:"report,omitempty"`
+}
+
+// List interface wraps a policy-list like structure.
+// The most important query you can perform is to fetch the policy
+// for a particular domain.
+type List interface {
+	Get(string) (TLSPolicy, error)
+}
+
+// RawList is a raw representation of the policy list.
+type RawList struct {
+	Timestamp     time.Time            `json:"timestamp"`
+	Expires       time.Time            `json:"expires"`
+	Version       string               `json:"version"`
+	Author        string               `json:"author"`
+	Pinsets       map[string]Pinset    `json:"pinsets"`
+	PolicyAliases map[string]TLSPolicy `json:"policy-aliases"`
+	Policies      map[string]TLSPolicy `json:"policies"`
+}
+
+// Get retrieves the TLSPolicy for a domain, and resolves
+// aliases if they exist.
+func (t RawList) Get(domain string) (TLSPolicy, error) {
+	policy, ok := t.Policies[domain]
+	if !ok {
+		return TLSPolicy{}, fmt.Errorf("Policy for %d doesn't exist")
+	}
+	if len(policy.PolicyAlias) > 0 {
+		policy, ok = t.PolicyAliases[policy.PolicyAlias]
+		if !ok {
+			return TLSPolicy{}, fmt.Errorf("Policy alias for %d doesn't exist")
+		}
+	}
+	return policy, nil
+}
+
+// UpdatedList wraps a RawList that is updated from a remote
+// policyURL every hour.
+type UpdatedList struct {
+	messages        chan policyRequest
+	updateFrequency time.Duration
+	policyURL       string
+}
+
+// Retrieve and parse RawList from policyURL.
+func (l UpdatedList) fetchRawList() (RawList, error) {
+	resp, err := http.Get(l.policyURL)
+	if err != nil {
+		return RawList{}, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	var policyList RawList
+	err = json.Unmarshal(body, &policyList)
+	if err != nil {
+		return RawList{}, err
+	}
+	return policyList, nil
+}
+
+// A request made to the worker thread.
+type policyRequest struct {
+	domain    string
+	responses chan TLSPolicy
+	errors    chan error
+}
+
+// This routine serializes all reads and writes to the policy list.
+func (l UpdatedList) worker() {
+	currentList, err := l.fetchRawList()
+	for true {
+		select {
+		case req := <-l.messages:
+			if err != nil {
+				req.errors <- err
+				continue
+			}
+			policy, err := currentList.Get(req.domain)
+			if err != nil {
+				req.errors <- err
+				continue
+			}
+			req.responses <- policy
+		case <-time.After(l.updateFrequency):
+			currentList, err = l.fetchRawList()
+		}
+	}
+}
+
+// Get safely retrieves a domain from the list. This will
+// wait for any outstanding writes to be performed before
+// reading.
+func (l UpdatedList) Get(domain string) (TLSPolicy, error) {
+	req := policyRequest{
+		domain:    domain,
+		responses: make(chan TLSPolicy),
+		errors:    make(chan error),
+	}
+	l.messages <- req
+	select {
+	case resp := <-req.responses:
+		return resp, nil
+	case err := <-req.errors:
+		return TLSPolicy{}, err
+	case <-time.After(time.Second * 3):
+		return TLSPolicy{}, fmt.Errorf("Timed out")
+	}
+}
+
+// CreateUpdatedList constructs and UpdatedList object and launches
+func CreateUpdatedList() UpdatedList {
+	list := UpdatedList{
+		messages:        make(chan policyRequest),
+		policyURL:       PolicyURL,
+		updateFrequency: time.Hour,
+	}
+	go list.worker()
+	return list
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -64,7 +64,7 @@ func (t RawList) Get(domain string) (TLSPolicy, error) {
 type listFetcher func(string) (RawList, error)
 
 // UpdatedList wraps a RawList that is updated from a remote
-// policyURL every hour.
+// policyURL every hour. Safe for concurrent calls to `Get`.
 type UpdatedList struct {
 	messages        chan policyRequest
 	updateFrequency time.Duration
@@ -137,7 +137,8 @@ func (l UpdatedList) Get(domain string) (TLSPolicy, error) {
 	}
 }
 
-// CreateUpdatedList constructs and UpdatedList object and launches
+// CreateUpdatedList constructs and UpdatedList object and launches a
+// worker thread to continually update it.
 func CreateUpdatedList() UpdatedList {
 	list := UpdatedList{
 		messages:        make(chan policyRequest),


### PR DESCRIPTION
Fixes #25.

Added a subpackage, `policy`, meant to handle parsing and regularly updating an in-memory representation of the TLS policy list. If it gets really large, we'll maybe want to persist this cache somehow, but for now this is alright.

`UpdatedList` wraps the actual List and performs periodic (hourly) fetches to it.
It isn't currently extensively used in the server code, but will be once we start using this machine to run periodic scans and to roll new changes to the policy list.

The other large change is the introduction of `policyCheck` in `api.go`. This isn't exactly where this function belongs, but it'll do for now since it relies on both `db` (to check if a domain has been queued but not on the list) and `policy` (to check if a domain has been added).