### PR TITLE
Don't return token information from /api/queue

### DIFF
--- a/api.go
+++ b/api.go
@@ -136,8 +136,7 @@ func getDomainParams(r *http.Request, domain string) (db.DomainData, error) {
 //        domain: Mail domain to queue a TLS policy for.
 //        email: Contact email associated with domain, to be verified.
 //        hostname_<n>: MX hostnames to put into this domain's TLS policy. n up to 8.
-//        Sets db.TokenData object as response.
-//        TODO (sydneyli): Return DomainData instead, to not expose token.
+//        Sets db.DomainData object as response.
 //   GET  /api/queue?domain=<domain>
 //        Sets db.DomainData object as response.
 func (api API) Queue(r *http.Request) APIResponse {
@@ -158,11 +157,11 @@ func (api API) Queue(r *http.Request) APIResponse {
 			return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		}
 		// 2. Create token for domain
-		token, err := api.Database.PutToken(domain)
+		_, err = api.Database.PutToken(domain)
 		if err != nil {
 			return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		}
-		return APIResponse{StatusCode: http.StatusOK, Response: token}
+		return APIResponse{StatusCode: http.StatusOK, Response: domainData}
 		// GET: Retrieve domain status from queue
 	} else if r.Method == http.MethodGet {
 		status, err := api.Database.GetDomain(domain)

--- a/db/db.go
+++ b/db/db.go
@@ -64,6 +64,8 @@ type Database interface {
 	GetDomain(string) (DomainData, error)
 	// Retrieves all domains in a particular state.
 	GetDomains(DomainState) ([]DomainData, error)
+	// Gets the token for a domain
+	GetTokenByDomain(string) (string, error)
 	// Creates a token in the db
 	PutToken(string) (TokenData, error)
 	// Uses a token in the db

--- a/db/memdb.go
+++ b/db/memdb.go
@@ -31,6 +31,16 @@ func randToken() string {
 	return fmt.Sprintf("%x", b)
 }
 
+// GetTokenByDomain gets the token for a domain name.
+func (db *MemDatabase) GetTokenByDomain(domain string) (string, error) {
+	for token, tokenData := range db.tokens {
+		if tokenData.Domain == domain {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("Couldn't find an entry for this domain")
+}
+
 // UseToken uses the e-mail token specified by tokenStr.
 func (db *MemDatabase) UseToken(tokenStr string) (string, error) {
 	token, ok := db.tokens[tokenStr]
@@ -52,18 +62,9 @@ func (db *MemDatabase) UseToken(tokenStr string) (string, error) {
 	return token.Domain, nil
 }
 
-func (db *MemDatabase) getTokenForDomain(domain string) (string, error) {
-	for token, tokenData := range db.tokens {
-		if tokenData.Domain == domain {
-			return token, nil
-		}
-	}
-	return "", fmt.Errorf("Couldn't find an entry for this domain")
-}
-
 // PutToken inserts a randomly generated token for domain. Returns the token.
 func (db *MemDatabase) PutToken(domain string) (TokenData, error) {
-	existingToken, err := db.getTokenForDomain(domain)
+	existingToken, err := db.GetTokenByDomain(domain)
 	if err == nil {
 		delete(db.tokens, existingToken)
 	}

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -53,6 +53,16 @@ func (db *SQLDatabase) UseToken(tokenStr string) (string, error) {
 	return domain, err
 }
 
+// GetTokenByDomain gets the token for a domain name.
+func (db *SQLDatabase) GetTokenByDomain(domain string) (string, error) {
+	var token string
+	err := db.conn.QueryRow("SELECT token FROM tokens WHERE domain=?", domain).Scan(&token)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
 // PutToken generates and inserts a token into the database for a particular
 // domain, and returns the resulting token row.
 func (db *SQLDatabase) PutToken(domain string) (TokenData, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -216,21 +216,21 @@ func TestQueueTwice(t *testing.T) {
 		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
 		return
 	}
-	// 2. Extract token from queue.
-	tokenBody, _ := ioutil.ReadAll(resp.Body)
-	tokenData := db.TokenData{}
-	err := json.Unmarshal(tokenBody, &APIResponse{Response: &tokenData})
+
+	// 2. Get token from DB
+	token, err := api.Database.GetTokenByDomain("eff.org")
 	if err != nil {
-		t.Errorf("Couldn't unmarshal JSON into TokenData object: %v", err)
+		t.Errorf("Token for eff.org not found in database")
 		return
 	}
-	token := tokenData.Token
+
 	// 3. Request to be queued again.
 	resp = testRequest("POST", "/api/queue", data, api.Queue)
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
 		return
 	}
+
 	// 4. Old token shouldn't work.
 	data = url.Values{}
 	data.Set("token", token)

--- a/main_test.go
+++ b/main_test.go
@@ -112,6 +112,23 @@ func TestGetDomainHidesEmail(t *testing.T) {
 	}
 }
 
+func TestQueueDomainHidesToken(t *testing.T) {
+	data := url.Values{}
+	data.Set("domain", "eff.org")
+	data.Set("email", "testing@fake-email.org")
+	data.Set("hostname_0", ".eff.org")
+	resp := testRequest("POST", "/api/queue", data, api.Queue)
+
+	token, err := api.Database.GetTokenByDomain("eff.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseBody, _ := ioutil.ReadAll(resp.Body)
+	if bytes.Contains(responseBody, []byte(token)) {
+		t.Errorf("Queueing domain leaks validation token")
+	}
+}
+
 // Tests basic queuing workflow.
 // Requests domain to be queued, and validates corresponding e-mail token.
 // Domain status should then be updated to "queued".


### PR DESCRIPTION
Resolves #29 

Adds a database helper to get the token for a given domain and uses that helper to validate the token in tests.