### PR TITLE
Test cleanup

### DIFF
--- a/api.go
+++ b/api.go
@@ -136,8 +136,7 @@ func getDomainParams(r *http.Request, domain string) (db.DomainData, error) {
 //        domain: Mail domain to queue a TLS policy for.
 //        email: Contact email associated with domain, to be verified.
 //        hostname_<n>: MX hostnames to put into this domain's TLS policy. n up to 8.
-//        Sets db.TokenData object as response.
-//        TODO (sydneyli): Return DomainData instead, to not expose token.
+//        Sets db.DomainData object as response.
 //   GET  /api/queue?domain=<domain>
 //        Sets db.DomainData object as response.
 func (api API) Queue(r *http.Request) APIResponse {
@@ -158,11 +157,11 @@ func (api API) Queue(r *http.Request) APIResponse {
 			return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		}
 		// 2. Create token for domain
-		token, err := api.Database.PutToken(domain)
+		_, err = api.Database.PutToken(domain)
 		if err != nil {
 			return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		}
-		return APIResponse{StatusCode: http.StatusOK, Response: token}
+		return APIResponse{StatusCode: http.StatusOK, Response: domainData}
 		// GET: Retrieve domain status from queue
 	} else if r.Method == http.MethodGet {
 		status, err := api.Database.GetDomain(domain)

--- a/db/db.go
+++ b/db/db.go
@@ -64,6 +64,8 @@ type Database interface {
 	GetDomain(string) (DomainData, error)
 	// Retrieves all domains in a particular state.
 	GetDomains(DomainState) ([]DomainData, error)
+	// Gets the token for a domain
+	GetTokenByDomain(string) (string, error)
 	// Creates a token in the db
 	PutToken(string) (TokenData, error)
 	// Uses a token in the db

--- a/db/memdb.go
+++ b/db/memdb.go
@@ -31,6 +31,16 @@ func randToken() string {
 	return fmt.Sprintf("%x", b)
 }
 
+// GetTokenByDomain gets the token for a domain name.
+func (db *MemDatabase) GetTokenByDomain(domain string) (string, error) {
+	for token, tokenData := range db.tokens {
+		if tokenData.Domain == domain {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("Couldn't find an entry for this domain")
+}
+
 // UseToken uses the e-mail token specified by tokenStr.
 func (db *MemDatabase) UseToken(tokenStr string) (string, error) {
 	token, ok := db.tokens[tokenStr]
@@ -52,18 +62,9 @@ func (db *MemDatabase) UseToken(tokenStr string) (string, error) {
 	return token.Domain, nil
 }
 
-func (db *MemDatabase) getTokenForDomain(domain string) (string, error) {
-	for token, tokenData := range db.tokens {
-		if tokenData.Domain == domain {
-			return token, nil
-		}
-	}
-	return "", fmt.Errorf("Couldn't find an entry for this domain")
-}
-
 // PutToken inserts a randomly generated token for domain. Returns the token.
 func (db *MemDatabase) PutToken(domain string) (TokenData, error) {
-	existingToken, err := db.getTokenForDomain(domain)
+	existingToken, err := db.GetTokenByDomain(domain)
 	if err == nil {
 		delete(db.tokens, existingToken)
 	}

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -53,6 +53,16 @@ func (db *SQLDatabase) UseToken(tokenStr string) (string, error) {
 	return domain, err
 }
 
+// GetTokenByDomain gets the token for a domain name.
+func (db *SQLDatabase) GetTokenByDomain(domain string) (string, error) {
+	var token string
+	err := db.conn.QueryRow("SELECT token FROM tokens WHERE domain=?", domain).Scan(&token)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
 // PutToken generates and inserts a token into the database for a particular
 // domain, and returns the resulting token row.
 func (db *SQLDatabase) PutToken(domain string) (TokenData, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -216,21 +216,21 @@ func TestQueueTwice(t *testing.T) {
 		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
 		return
 	}
-	// 2. Extract token from queue.
-	tokenBody, _ := ioutil.ReadAll(resp.Body)
-	tokenData := db.TokenData{}
-	err := json.Unmarshal(tokenBody, &APIResponse{Response: &tokenData})
+
+	// 2. Get token from DB
+	token, err := api.Database.GetTokenByDomain("eff.org")
 	if err != nil {
-		t.Errorf("Couldn't unmarshal JSON into TokenData object: %v", err)
+		t.Errorf("Token for eff.org not found in database")
 		return
 	}
-	token := tokenData.Token
+
 	// 3. Request to be queued again.
 	resp = testRequest("POST", "/api/queue", data, api.Queue)
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
 		return
 	}
+
 	// 4. Old token shouldn't work.
 	data = url.Values{}
 	data.Set("token", token)

--- a/main_test.go
+++ b/main_test.go
@@ -48,17 +48,14 @@ func TestMain(m *testing.M) {
 func TestInvalidPort(t *testing.T) {
 	portString, err := validPort("8000")
 	if err != nil {
-		t.Errorf("Should not have errored on valid string: %v", err)
-		return
+		t.Fatalf("Should not have errored on valid string: %v", err)
 	}
 	if portString != ":8000" {
-		t.Errorf("Expected portstring be :8000 instead of %s", portString)
-		return
+		t.Fatalf("Expected portstring be :8000 instead of %s", portString)
 	}
 	portString, err = validPort("80a")
 	if err == nil {
-		t.Errorf("Expected error on invalid port")
-		return
+		t.Fatalf("Expected error on invalid port")
 	}
 }
 
@@ -147,8 +144,7 @@ func TestBasicQueueWorkflow(t *testing.T) {
 	queueDomainPostData := validQueueData()
 	resp := testRequest("POST", "/api/queue", queueDomainPostData, api.Queue)
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
-		return
+		t.Fatalf("POST to api/queue failed with error %d", resp.StatusCode)
 	}
 	if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
 		t.Errorf("Expecting JSON content-type!")
@@ -162,23 +158,19 @@ func TestBasicQueueWorkflow(t *testing.T) {
 	domainData := db.DomainData{}
 	err := json.Unmarshal(domainBody, &APIResponse{Response: &domainData})
 	if err != nil {
-		t.Errorf("Returned invalid JSON object:%v\n", string(domainBody))
-		return
+		t.Fatalf("Returned invalid JSON object:%v\n", string(domainBody))
 	}
 	if domainData.State != "unvalidated" {
-		t.Errorf("Initial state for domains should be 'unvalidated'")
-		return
+		t.Fatalf("Initial state for domains should be 'unvalidated'")
 	}
 	if len(domainData.MXs) != 2 {
-		t.Errorf("Domain should have loaded two hostnames into policy")
-		return
+		t.Fatalf("Domain should have loaded two hostnames into policy")
 	}
 
 	// 3. Validate domain token
 	token, err := api.Database.GetTokenByDomain(queueDomainPostData.Get("domain"))
 	if err != nil {
-		t.Errorf("Token not found in database")
-		return
+		t.Fatalf("Token not found in database")
 	}
 	tokenRequestData := url.Values{}
 	tokenRequestData.Set("token", token)
@@ -188,12 +180,10 @@ func TestBasicQueueWorkflow(t *testing.T) {
 	var responseObj map[string]interface{}
 	err = json.Unmarshal(domainBody, &responseObj)
 	if err != nil {
-		t.Errorf("Returned invalid JSON object:%v\n", string(domainBody))
-		return
+		t.Fatalf("Returned invalid JSON object:%v\n", string(domainBody))
 	}
 	if responseObj["response"] != queueDomainPostData.Get("domain") {
-		t.Errorf("Token was not validated for %s", queueDomainPostData.Get("domain"))
-		return
+		t.Fatalf("Token was not validated for %s", queueDomainPostData.Get("domain"))
 	}
 
 	// 3-T2. Ensure double-validation does not work.
@@ -208,12 +198,10 @@ func TestBasicQueueWorkflow(t *testing.T) {
 	domainBody, _ = ioutil.ReadAll(resp.Body)
 	err = json.Unmarshal(domainBody, &APIResponse{Response: &domainData})
 	if err != nil {
-		t.Errorf("Returned invalid JSON object:%v\n", string(domainBody))
-		return
+		t.Fatalf("Returned invalid JSON object:%v\n", string(domainBody))
 	}
 	if domainData.State != "queued" {
-		t.Errorf("Token validation should have automatically queued domain")
-		return
+		t.Fatalf("Token validation should have automatically queued domain")
 	}
 }
 
@@ -223,8 +211,7 @@ func TestQueueWithoutHostnames(t *testing.T) {
 	data.Set("email", "testing@fake-email.org")
 	resp := testRequest("POST", "/api/queue", data, api.Queue)
 	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("POST to api/queue should have failed with error %d", http.StatusBadRequest)
-		return
+		t.Fatalf("POST to api/queue should have failed with error %d", http.StatusBadRequest)
 	}
 }
 
@@ -233,22 +220,19 @@ func TestQueueTwice(t *testing.T) {
 	requestData := validQueueData()
 	resp := testRequest("POST", "/api/queue", requestData, api.Queue)
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
-		return
+		t.Fatalf("POST to api/queue failed with error %d", resp.StatusCode)
 	}
 
 	// 2. Get token from DB
 	token, err := api.Database.GetTokenByDomain("eff.org")
 	if err != nil {
-		t.Errorf("Token for eff.org not found in database")
-		return
+		t.Fatalf("Token for eff.org not found in database")
 	}
 
 	// 3. Request to be queued again.
 	resp = testRequest("POST", "/api/queue", requestData, api.Queue)
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
-		return
+		t.Fatalf("POST to api/queue failed with error %d", resp.StatusCode)
 	}
 
 	// 4. Old token shouldn't work.
@@ -270,8 +254,7 @@ func TestBasicScan(t *testing.T) {
 	data.Set("domain", "eff.org")
 	resp := testRequest("POST", "/api/scan", data, api.Scan)
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("POST to api/scan failed with error %d", resp.StatusCode)
-		return
+		t.Fatalf("POST to api/scan failed with error %d", resp.StatusCode)
 	}
 	if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
 		t.Errorf("Expecting JSON content-type!")
@@ -291,8 +274,7 @@ func TestBasicScan(t *testing.T) {
 	// Check to see that scan results persisted.
 	resp = testRequest("GET", "api/scan?domain=eff.org", nil, api.Scan)
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("GET api/scan?domain=eff.org failed with error %d", resp.StatusCode)
-		return
+		t.Fatalf("GET api/scan?domain=eff.org failed with error %d", resp.StatusCode)
 	}
 	if resp.Header.Get("Content-Type") != "application/json; charset=utf-8" {
 		t.Errorf("Expecting JSON content-type!")

--- a/main_test.go
+++ b/main_test.go
@@ -112,6 +112,23 @@ func TestGetDomainHidesEmail(t *testing.T) {
 	}
 }
 
+func TestQueueDomainHidesToken(t *testing.T) {
+	data := url.Values{}
+	data.Set("domain", "eff.org")
+	data.Set("email", "testing@fake-email.org")
+	data.Set("hostname_0", ".eff.org")
+	resp := testRequest("POST", "/api/queue", data, api.Queue)
+
+	token, err := api.Database.GetTokenByDomain("eff.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseBody, _ := ioutil.ReadAll(resp.Body)
+	if bytes.Contains(responseBody, []byte(token)) {
+		t.Errorf("Queueing domain leaks validation token")
+	}
+}
+
 // Tests basic queuing workflow.
 // Requests domain to be queued, and validates corresponding e-mail token.
 // Domain status should then be updated to "queued".

--- a/main_test.go
+++ b/main_test.go
@@ -230,12 +230,8 @@ func TestQueueWithoutHostnames(t *testing.T) {
 
 func TestQueueTwice(t *testing.T) {
 	// 1. Request to be queued
-	data := url.Values{}
-	data.Set("domain", "eff.org")
-	data.Set("email", "testing@fake-email.org")
-	data.Set("hostname_0", ".eff.org")
-	data.Set("hostname_1", "mx.eff.org")
-	resp := testRequest("POST", "/api/queue", data, api.Queue)
+	requestData := validQueueData()
+	resp := testRequest("POST", "/api/queue", requestData, api.Queue)
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
 		return
@@ -249,16 +245,16 @@ func TestQueueTwice(t *testing.T) {
 	}
 
 	// 3. Request to be queued again.
-	resp = testRequest("POST", "/api/queue", data, api.Queue)
+	resp = testRequest("POST", "/api/queue", requestData, api.Queue)
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("POST to api/queue failed with error %d", resp.StatusCode)
 		return
 	}
 
 	// 4. Old token shouldn't work.
-	data = url.Values{}
-	data.Set("token", token)
-	resp = testRequest("POST", "/api/validate", data, api.Validate)
+	requestData = url.Values{}
+	requestData.Set("token", token)
+	resp = testRequest("POST", "/api/validate", requestData, api.Validate)
 	if resp.StatusCode != 400 {
 		t.Errorf("Old validation token shouldn't work.")
 	}


### PR DESCRIPTION
* For test failures that shop stop the execution of a test, call [t.Fatalf](https://golang.org/pkg/testing/#B.Fatalf) rather than t.Errorf + return.
* Refactor valid request data to queue a domain into a helper, to keep the code DRYer and ensure that tests that expect valid data have it.