### PR TITLE
fix(scan): scandata is JSON rather than string

### DIFF
--- a/api.go
+++ b/api.go
@@ -18,7 +18,7 @@ import (
 
 // Type for performing checks against an input domain. Returns
 // a JSON-formatted string.
-type checkPerformer func(string) (string, error)
+type checkPerformer func(string) (interface{}, error)
 
 // API is the HTTP API that this service provides.
 // All requests respond with an APIResponse JSON, with fields:
@@ -53,10 +53,9 @@ func apiWrapper(api apiHandler) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func defaultCheck(domain string) (string, error) {
+func defaultCheck(domain string) (interface{}, error) {
 	result := checker.CheckDomain(domain, nil)
-	byteArray, err := json.Marshal(result)
-	return string(byteArray), err
+	return result, nil
 }
 
 // Scan is the handler for /api/scan.
@@ -89,7 +88,6 @@ func (api API) Scan(r *http.Request) APIResponse {
 		if err != nil {
 			return APIResponse{StatusCode: http.StatusInternalServerError, Message: err.Error()}
 		}
-		// 3. TODO: Return scandata as JSON (also set response type)
 		return APIResponse{StatusCode: http.StatusOK, Response: scandata}
 		// GET: Just fetch the most recent scan
 	} else if r.Method == http.MethodGet {

--- a/db/db.go
+++ b/db/db.go
@@ -16,9 +16,9 @@ import (
 // ScanData each represent the result of a single scan, conducted using
 // starttls-checker.
 type ScanData struct {
-	Domain    string    `json:"domain"`    // Input domain
-	Data      string    `json:"scandata"`  // JSON blob: scan results from starttls-checker
-	Timestamp time.Time `json:"timestamp"` // Time at which this scan was conducted
+	Domain    string      `json:"domain"`    // Input domain
+	Data      interface{} `json:"scandata"`  // JSON blob: scan results from starttls-checker
+	Timestamp time.Time   `json:"timestamp"` // Time at which this scan was conducted
 }
 
 // DomainState represents the state of a single domain.

--- a/db/sqldb_test.go
+++ b/db/sqldb_test.go
@@ -119,7 +119,7 @@ func TestGetAllScans(t *testing.T) {
 	if len(data) != 2 {
 		t.Errorf("Expected GetAllScans to return two items, returned %d\n", len(data))
 	}
-	if data[0].Data != "test1" || data[1].Data != "test2" {
+	if data[0].Data != "\"test1\"" || data[1].Data != "\"test2\"" {
 		t.Errorf("Expected Data of scan objects to include both test1 and test2")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/EFForg/starttls-check/checker"
 	"github.com/EFForg/starttls-scanner/db"
 )
 
@@ -21,8 +22,8 @@ import (
 
 var api *API
 
-func mockCheckPerform(domain string) (string, error) {
-	return fmt.Sprintf("{\n\"domain\": \"%s\"\n}", domain), nil
+func mockCheckPerform(domain string) (interface{}, error) {
+	return checker.DomainResult{Domain: domain, Message: "testequal"}, nil
 }
 
 // Load env. vars, initialize DB hook, and tests API
@@ -262,7 +263,8 @@ func TestBasicScan(t *testing.T) {
 
 	// Checking response JSON returns successful scan
 	scanBody, _ := ioutil.ReadAll(resp.Body)
-	scanData := db.ScanData{}
+	checkResult := checker.DomainResult{}
+	scanData := db.ScanData{Data: &checkResult}
 	err := json.Unmarshal(scanBody, &APIResponse{Response: &scanData})
 	if err != nil {
 		t.Errorf("Returned invalid JSON object:%v\n%v\n", string(scanBody), err)
@@ -282,7 +284,8 @@ func TestBasicScan(t *testing.T) {
 
 	// Checking response JSON returns scan associated with domain
 	scanBody, _ = ioutil.ReadAll(resp.Body)
-	scanData2 := db.ScanData{}
+	checkResult2 := checker.DomainResult{}
+	scanData2 := db.ScanData{Data: &checkResult2}
 	err = json.Unmarshal(scanBody, &APIResponse{Response: &scanData2})
 	if err != nil {
 		t.Errorf("Returned invalid JSON object:%v\n", string(scanBody))
@@ -290,7 +293,7 @@ func TestBasicScan(t *testing.T) {
 	if scanData2.Domain != "eff.org" {
 		t.Errorf("Scan JSON expected to have Domain: eff.org, not %s\n", scanData2.Domain)
 	}
-	if strings.Compare(scanData2.Data, scanData.Data) != 0 {
-		t.Errorf("Scan JSON mismatch:\n%v\n%v\n", scanData2.Data, scanData.Data)
+	if strings.Compare(checkResult.Domain, checkResult2.Domain) != 0 {
+		t.Errorf("Scan JSON mismatch:\n%v\n%v\n", checkResult.Domain, checkResult2.Domain)
 	}
 }


### PR DESCRIPTION
Fixes #37 

A quick fix, while maintaining `db` and `api` as agnostic to the scan data object's type.

Though, another option (which is arguably cleaner) is to continue with `db.ScanData.Data` as a `string` rather than `interface{}` and create a new `ScanData` object with which to serialize the JSON in API.

Thoughts?