### PR TITLE
fix(tests): when run with SQL database, tests were failing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -31,10 +31,10 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Note: we can use either MemDatabase or SqlDatabase here, should not make a difference.
-	// db, err := db.InitSqlDatabase(cfg)
+	// Note: we can use either MemDatabase or SQLDatabase here, should not make a difference.
+	// db, err := db.InitSQLDatabase(cfg)
 	// if err != nil {
-	//     log.Fatal(err)
+	// 	log.Fatal(err)
 	// }
 	api = &API{
 		Database:    db.InitMemDatabase(cfg),
@@ -125,7 +125,6 @@ func TestGetDomainHidesEmail(t *testing.T) {
 func TestQueueDomainHidesToken(t *testing.T) {
 	requestData := validQueueData()
 	resp := testRequest("POST", "/api/queue", requestData, api.Queue)
-
 	token, err := api.Database.GetTokenByDomain(requestData.Get("domain"))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Uh oh! Realized that some SQL tests were actually failing secretly, because we haven't set them up properly on Travis. This should fix them.

#39 should prevent things like this from happening in the future. For now, I should remember to swap out `MemDatabase` with `SQLDatabase` in `main_test` when testing/reviewing PRs and my own changes, as well as running `go test ./db`.