### PR TITLE
feat(api): domain dont-scan list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 PORT=8080
 # Permitted domains for cross-origin requests, e.g. http://localhost:1313
 ALLOWED_ORIGINS=
+# Filepath to domain blacklist
+DOMAIN_BLACKLIST=
+# Filepath to IP blacklist
+IP_BLACKLIST=
 
 # The name of the database, e.g. `starttls` or `starttls_dev`
 # (this should be created in advance)

--- a/api.go
+++ b/api.go
@@ -32,6 +32,7 @@ type checkPerformer func(string) (checker.DomainResult, error)
 type API struct {
 	Database    db.Database
 	CheckDomain checkPerformer
+	DontScan    map[string]bool
 }
 
 // APIResponse wraps all the responses from this API.
@@ -69,6 +70,12 @@ func (api API) Scan(r *http.Request) APIResponse {
 	domain, err := getASCIIDomain(r)
 	if err != nil {
 		return APIResponse{StatusCode: http.StatusBadRequest, Message: err.Error()}
+	}
+	// Check if we shouldn't scan this domain
+	if api.DontScan != nil {
+		if _, ok := api.DontScan[domain]; ok {
+			return APIResponse{StatusCode: http.StatusTooManyRequests}
+		}
 	}
 	// POST: Force scan to be conducted
 	if r.Method == http.MethodPost {

--- a/db/db.go
+++ b/db/db.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/EFForg/starttls-check/checker"
-	"github.com/joho/godotenv"
 )
 
 ///////////////////////////////////////
@@ -99,7 +98,6 @@ var configDefaults = map[string]string{
 }
 
 func getEnvOrDefault(varName string) string {
-	godotenv.Load()
 	envVar := os.Getenv(varName)
 	if len(envVar) == 0 {
 		envVar = configDefaults[varName]

--- a/main.go
+++ b/main.go
@@ -44,8 +44,13 @@ func ServePublicEndpoints(api *API, cfg *db.Config) {
 	log.Fatal(http.ListenAndServe(portString, mainHandler))
 }
 
+// Loads a map of domains (effectively a set for fast lookup) to blacklist.
+// if `DOMAIN_BLACKLIST` is not set, returns an empty map.
 func loadDontScan() map[string]bool {
 	filepath := os.Getenv("DOMAIN_BLACKLIST")
+	if len(filepath) == 0 {
+		return make(map[string]bool)
+	}
 	data, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		log.Fatal(err)

--- a/main_test.go
+++ b/main_test.go
@@ -294,3 +294,13 @@ func TestBasicScan(t *testing.T) {
 		t.Errorf("Scan JSON mismatch:\n%v\n%v\n", scanData.Data.Domain, scanData2.Data.Domain)
 	}
 }
+
+func TestDontScanList(t *testing.T) {
+	api.DontScan = map[string]bool{"dontscan.com": true}
+	data := url.Values{}
+	data.Set("domain", "dontscan.com")
+	resp := testRequest("POST", "/api/scan", data, api.Scan)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("GET api/scan?domain=dontscan.com should have failed with %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
fixes #43. made a new issue for blacklisting IPs, since it'll be more involved (this would have to happen after the MX host lookup in the checker).

Also moved `godotenv` to `main.go` since we're using env vars in `api` as well as `db` now.