### PR TITLE
Rate limit by IP

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -116,7 +116,9 @@ func TestRateLimitByIP(t *testing.T) {
 	server := httptest.NewServer(registerHandlers(api, mux))
 	defer server.Close()
 
-	http.Get(fmt.Sprintf("%s/", server.URL))
+	for i := 0; i < 10; i++ {
+		http.Get(fmt.Sprintf("%s/", server.URL))
+	}
 	resp, err := http.Get(fmt.Sprintf("%s/", server.URL))
 
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -100,15 +100,31 @@ func TestPanicRecovery(t *testing.T) {
 	resp, err := http.Get(fmt.Sprintf("%s/panic", server.URL))
 
 	if err != nil {
-		t.Error(err)
+		t.Errorf("Request to panic endpoint failed: %s\n", err)
 	}
-	if resp.StatusCode != 500 {
-		t.Errorf("Expected server to respond with 500")
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Expected server to respond with 500, got %d", resp.StatusCode)
 	}
 }
 
 func panickingHandler(w http.ResponseWriter, r *http.Request) {
 	panic(fmt.Errorf("oh no"))
+}
+
+func TestRateLimitByIP(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(registerHandlers(api, mux))
+	defer server.Close()
+
+	http.Get(fmt.Sprintf("%s/", server.URL))
+	resp, err := http.Get(fmt.Sprintf("%s/", server.URL))
+
+	if err != nil {
+		t.Errorf("Rate limit request failed: %s\n", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("Expected server to respond with 429, got %d", resp.StatusCode)
+	}
 }
 
 // Helper function to mock a request to the server via https.


### PR DESCRIPTION
I looked into rate limiting a bit and it looks like rolling our own wouldn't be too hard, but involves a fair amount of code (eg final example in https://www.alexedwards.net/blog/how-to-rate-limit-http-requests), so i went with the [tollbooth](https://github.com/didip/tollbooth) package.

After integrating it, I realized this package only allows us to specify a maximum number of requests per second. It seems like we might want to permit certain actions less frequently than once/second/ip. I think that will require a different solution. We could use this in the meantime.