### PR TITLE
Format error strings

### DIFF
--- a/api.go
+++ b/api.go
@@ -191,15 +191,15 @@ func getDomainParams(r *http.Request, domain string) (db.DomainData, error) {
 			continue
 		}
 		if !validDomainName(strings.TrimPrefix(hostname, ".")) {
-			return domainData, fmt.Errorf("Hostname %s is invalid", hostname)
+			return domainData, fmt.Errorf("hostname %s is invalid", hostname)
 		}
 		domainData.MXs = append(domainData.MXs, hostname)
 	}
 	if len(domainData.MXs) == 0 {
-		return domainData, fmt.Errorf("No hostnames supplied for domain's TLS policy")
+		return domainData, fmt.Errorf("no MX hostnames supplied for domain %s", domain)
 	}
 	if len(domainData.MXs) > MaxHostnames {
-		return domainData, fmt.Errorf("No more than 8 MX hostnames are permitted")
+		return domainData, fmt.Errorf("no more than 8 MX hostnames are permitted")
 	}
 	return domainData, nil
 }

--- a/db/memdb.go
+++ b/db/memdb.go
@@ -38,20 +38,20 @@ func (db *MemDatabase) GetTokenByDomain(domain string) (string, error) {
 			return token, nil
 		}
 	}
-	return "", fmt.Errorf("Couldn't find an entry for this domain")
+	return "", fmt.Errorf("no token found for domain %s", domain)
 }
 
 // UseToken uses the e-mail token specified by tokenStr.
 func (db *MemDatabase) UseToken(tokenStr string) (string, error) {
 	token, ok := db.tokens[tokenStr]
 	if !ok {
-		return "", fmt.Errorf("This token doesn't exist")
+		return "", fmt.Errorf("token doesn't exist")
 	}
 	if token.Used {
-		return "", fmt.Errorf("This token has already been used")
+		return "", fmt.Errorf("token has already been used")
 	}
 	if token.Expires.Before(time.Now()) {
-		return "", fmt.Errorf("This token has expired")
+		return "", fmt.Errorf("token has expired")
 	}
 	db.tokens[tokenStr] = TokenData{
 		Domain:  token.Domain,
@@ -92,7 +92,7 @@ func (db *MemDatabase) PutScan(scanData ScanData) error {
 func (db MemDatabase) GetLatestScan(domain string) (ScanData, error) {
 	val, ok := db.scans[domain]
 	if !ok {
-		return ScanData{}, fmt.Errorf("No scans conducted for domain %s", domain)
+		return ScanData{}, fmt.Errorf("no scans found for domain %s", domain)
 	}
 	return val[len(val)-1], nil
 }
@@ -101,7 +101,7 @@ func (db MemDatabase) GetLatestScan(domain string) (ScanData, error) {
 func (db MemDatabase) GetAllScans(domain string) ([]ScanData, error) {
 	val, ok := db.scans[domain]
 	if !ok {
-		return nil, fmt.Errorf("No scans conducted for domain %s", domain)
+		return nil, fmt.Errorf("no scans found for domain %s", domain)
 	}
 	return val, nil
 }

--- a/db/sqldb.go
+++ b/db/sqldb.go
@@ -184,7 +184,7 @@ func (db SQLDatabase) GetDomains(state DomainState) ([]DomainData, error) {
 func tryExec(database SQLDatabase, commands []string) error {
 	for _, command := range commands {
 		if _, err := database.conn.Exec(command); err != nil {
-			return fmt.Errorf("The following command failed:\n%s\nWith error:\n%v",
+			return fmt.Errorf("command failed: %s\nwith error: %v",
 				command, err.Error())
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 
 func validPort(port string) (string, error) {
 	if _, err := strconv.Atoi(port); err != nil {
-		return "", fmt.Errorf("Given portstring %s is invalid", port)
+		return "", fmt.Errorf("portstring %s is invalid", port)
 	}
 	return fmt.Sprintf(":%s", port), nil
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -45,12 +45,12 @@ type list struct {
 func (l list) get(domain string) (TLSPolicy, error) {
 	policy, ok := l.Policies[domain]
 	if !ok {
-		return TLSPolicy{}, fmt.Errorf("Policy for %s doesn't exist", domain)
+		return TLSPolicy{}, fmt.Errorf("policy for domain %s doesn't exist", domain)
 	}
 	if len(policy.PolicyAlias) > 0 {
 		policy, ok = l.PolicyAliases[policy.PolicyAlias]
 		if !ok {
-			return TLSPolicy{}, fmt.Errorf("Policy alias for %s doesn't exist", domain)
+			return TLSPolicy{}, fmt.Errorf("policy alias for domain %s doesn't exist", domain)
 		}
 	}
 	return policy, nil


### PR DESCRIPTION
Use lowercase letters for error messages, also tweaked the wording a teeny bit for consistency

Closes #34 