### PR TITLE
Merge checker repo into scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.8"
+  - "1.10"
 
 addons:
   postgresql: "9.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 install:
   - go get -u github.com/golang/lint/golint
-  - go get ./...
+  - go get -t ./...
 
 before_script:
   - psql -c 'CREATE DATABASE starttls_test;' -U postgres

--- a/checker/README.md
+++ b/checker/README.md
@@ -1,0 +1,64 @@
+# STARTTLS Check
+Evaluates an @mail domain on how secure its TLS settings are. First retrieves
+all MX records for the domain, then performs a series of checks on each
+discovered hostname's port 25.
+
+If `$HOSTNAME` environment variable is set, this is used in the SMTP hello.
+
+## What does it check?
+For each hostname found via a MX lookup, we check:
+ - Can connect (over SMTP) on port 25
+ - STARTTLS support
+ - Presents a valid certificate
+ - TLS version up-to-date
+ - Secure TLS ciphers
+
+## Build
+
+As a library
+
+```
+go get github.com/efforg/starttls-scanner/checker
+```
+
+or if you want to use it as a bin command
+
+```
+go get github.com/efforg/starttls-scanner/checker/cmd/starttls-check
+```
+
+NOTE: many ISPs block outbound port 25 to mitigate botnet e-mail spam. If you are on a residential IP, you might not be able to run this tool!
+
+## API
+
+The most important API that we provide is checker.CheckDomain(domain string, mxHostnames []string) DomainResult; which performs all associated checks for a particular domain.
+
+This first performs an MX lookup, then performs checks on each of the resulting hostnames. The Status of DomainResult is inherited from the check status of the MX records with the highest priority. So, the Status is set to Success only when all high priority hostnames also have the Success status.
+
+The reason we only require the highest-priority mailservers to pass is because many deploy dummy mailservers as a spam mitigation.
+
+We do, however, provide the check information for the additional hostnames-- they just don't affect the status of the primary domain check.
+
+## Command Line Usage
+
+```
+starttls-check -domain <email domain> 
+```
+
+For instance, running `./starttls-check -domain gmail.com` will
+check for the TLS configurations (over SMTP) on port 25 for all the MX domains for `gmail.com`.
+
+
+## Results
+From a preliminary STARTTLS scan on the top 1000 alexa domains, performed 3/8/2018, we found:
+ - 20.19% of 421 unique MX hostnames don't support STARTTLS.
+ - 36.01% of the servers which support STARTTLS didn't present valid certificates.
+    - We're not sure how to define valid certificates. On manual inspection, although many certificates are self-signed, it seems that many of these certs are issued for other subdomains owned by the same entity.
+
+Seems like an improvement from results in [2014](https://research.google.com/pubs/pub43962.html), but we can do better!
+
+
+## TODO
+ - [ ] Check DANE
+ - [ ] Present recommendations for issues
+ - [ ] Tests

--- a/checker/check.go
+++ b/checker/check.go
@@ -1,0 +1,77 @@
+package checker
+
+import "fmt"
+
+// CheckStatus is an enum encoding the status of the overall check.
+type CheckStatus int32
+
+// Values for CheckStatus
+const (
+	Success CheckStatus = 0
+	Warning CheckStatus = 1
+	Failure CheckStatus = 2
+	Error   CheckStatus = 3
+)
+
+// SetStatus the resulting status of combining old & new. The order of priority
+// for CheckStatus goes: Error > Failure > Warning > Success
+func SetStatus(oldStatus CheckStatus, newStatus CheckStatus) CheckStatus {
+	if newStatus > oldStatus {
+		return newStatus
+	}
+	return oldStatus
+}
+
+// CheckResult the result of a singular check. It's agnostic to the nature
+// of the check performed, and simply stores a reference to the check's name,
+// a summary of what the check should do, as well as any error, failure, or
+// warning messages associated.
+type CheckResult struct {
+	Name     string      `json:"name"`
+	Status   CheckStatus `json:"status"`
+	Messages []string    `json:"messages,omitempty"`
+}
+
+// Ensures the Messages field is initialized.
+func (c *CheckResult) ensureInit() {
+	if c.Messages == nil {
+		c.Messages = make([]string, 0)
+	}
+}
+
+// Error adds an error message to this check result.
+// The Error status will override any other existing status for this check.
+// Typically, when a check encounters an error, it stops executing.
+func (c CheckResult) Error(format string, a ...interface{}) CheckResult {
+	c.ensureInit()
+	c.Status = SetStatus(c.Status, Error)
+	c.Messages = append(c.Messages, fmt.Sprintf("Error: "+format, a...))
+	return c
+}
+
+// Failure adds a failure message to this check result.
+// The Failure status will override any Status other than Error.
+// Whenever Failure is called, the entire check is failed.
+func (c CheckResult) Failure(format string, a ...interface{}) CheckResult {
+	c.ensureInit()
+	c.Status = SetStatus(c.Status, Failure)
+	c.Messages = append(c.Messages, fmt.Sprintf("Failure: "+format, a...))
+	return c
+}
+
+// Warning adds a warning message to this check result.
+// The Warning status only supercedes the Success status.
+func (c CheckResult) Warning(format string, a ...interface{}) CheckResult {
+	c.ensureInit()
+	c.Status = SetStatus(c.Status, Warning)
+	c.Messages = append(c.Messages, fmt.Sprintf("Warning: "+format, a...))
+	return c
+}
+
+// Success simply sets the status of CheckResult to a Success.
+// Status is set if no other status has been declared on this check.
+func (c CheckResult) Success() CheckResult {
+	c.ensureInit()
+	c.Status = SetStatus(c.Status, Success)
+	return c
+}

--- a/checker/cmd/starttls-check/cmd.go
+++ b/checker/cmd/starttls-check/cmd.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/EFForg/starttls-check/checker"
+)
+
+// Expects domains to be delimited by newlines.
+func domainsFromFile(filename string) ([]string, error) {
+	buff, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	allContent := string(buff)
+	// Filter empty lines from domain list
+	filterDomains := make([]string, 0)
+	for _, line := range strings.Split(allContent, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		filterDomains = append(filterDomains, trimmed)
+	}
+	return filterDomains, nil
+}
+
+// Run a series of security checks on an MTA domain.
+// =================================================
+// Validating (START)TLS configurations for all MX domains.
+//
+// CLI arguments
+// =============
+//     -domain <domain> The domain to perform checks against.
+//
+func main() {
+	// 1. Setup and parse arguments.
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "\nNOTE: All checks are enabled by default. "+
+			"Setting any individual 'enable check' flag will disable "+
+			"all checks other than the ones explicitly specified.\n\n")
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	domainStr := flag.String("domain", "", "Required: Domain to check TLS for.")
+	flag.Parse()
+	if *domainStr == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	result := checker.CheckDomain(*domainStr, nil)
+	b, err := json.Marshal(result)
+	if err != nil {
+		fmt.Printf("%q", err)
+	}
+	fmt.Println(string(b))
+}

--- a/checker/domain.go
+++ b/checker/domain.go
@@ -17,6 +17,7 @@ func (d DomainResult) reportError(err error) DomainResult {
 	return d
 }
 
+// DomainStatus indicates the overall status of a single domain.
 type DomainStatus int32
 
 // In order of precedence.

--- a/checker/domain.go
+++ b/checker/domain.go
@@ -1,0 +1,121 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"golang.org/x/net/idna"
+)
+
+// Reports an error during the domain checks.
+func (d DomainResult) reportError(err error) DomainResult {
+	d.Status = DomainError
+	d.Message = err.Error()
+	return d
+}
+
+type DomainStatus int32
+
+// In order of precedence.
+const (
+	DomainSuccess           DomainStatus = 0
+	DomainWarning           DomainStatus = 1
+	DomainFailure           DomainStatus = 2
+	DomainError             DomainStatus = 3
+	DomainNoSTARTTLSFailure DomainStatus = 4
+	DomainCouldNotConnect   DomainStatus = 5
+)
+
+// DomainResult wraps all the results for a particular mail domain.
+type DomainResult struct {
+	// Domain being checked against.
+	Domain string `json:"domain"`
+	// Message if a failure or error occurs on the domain lookup level.
+	Message string `json:"message,omitempty"`
+	// Status of this check, inherited from the results of preferred hostnames.
+	Status DomainStatus `json:"status"`
+	// Results of this check, on each hostname.
+	HostnameResults map[string]HostnameResult `json:"results"`
+	// The list of hostnames which impact the Status of this result.
+	// Determined by the hostnames with the lowest MX priority.
+	PreferredHostnames []string `json:"preferred_hostnames"`
+	// Expected MX hostnames supplied by the caller of CheckDomain.
+	MxHostnames []string `json:"mx_hostnames,omitempty"`
+	// Extra global results
+	ExtraResults map[string]CheckResult `json:"extra_results,omitempty"`
+}
+
+func lookupMXWithTimeout(domain string) ([]*net.MX, error) {
+	const timeout = 2 * time.Second
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+	var r net.Resolver
+	return r.LookupMX(ctx, domain)
+}
+
+func lookupHostnames(domain string) ([]string, error) {
+	domainASCII, err := idna.ToASCII(domain)
+	if err != nil {
+		return nil, fmt.Errorf("domain name %s couldn't be converted to ASCII", domain)
+	}
+	mxs, err := lookupMXWithTimeout(domainASCII)
+	if err != nil || len(mxs) == 0 {
+		return nil, fmt.Errorf("No MX records found")
+	}
+	hostnames := make([]string, 0)
+	for _, mx := range mxs {
+		hostnames = append(hostnames, strings.ToLower(mx.Host))
+	}
+	return hostnames, nil
+}
+
+// CheckDomain performs all associated checks for a particular domain.
+// First performs an MX lookup, then performs subchecks on each of the
+// resulting hostnames.
+//
+// The status of DomainResult is inherited from the check status of the MX
+// records with highest priority. This check succeeds only if the hostname
+// checks on the highest priority mailservers succeed.
+//
+//   `domain` is the mail domain to perform the lookup on.
+//   `mxHostnames` is a list of expected hostnames for certificate validation.
+func CheckDomain(domain string, mxHostnames []string) DomainResult {
+	// 1. Look up hostnames
+	// 2. Perform and aggregate checks from those hostnames.
+	// 3. Set a summary message.
+	result := DomainResult{Domain: domain, MxHostnames: mxHostnames}
+	hostnames, err := lookupHostnames(domain)
+	if err != nil {
+		return result.reportError(err)
+	}
+	checkedHostnames := make([]string, 0)
+	result.HostnameResults = make(map[string]HostnameResult)
+	for _, hostname := range hostnames {
+		result.HostnameResults[hostname] = CheckHostname(domain, hostname, mxHostnames)
+		if result.HostnameResults[hostname].couldConnect() {
+			checkedHostnames = append(checkedHostnames, hostname)
+		}
+	}
+	result.PreferredHostnames = checkedHostnames
+
+	// Derive Domain code from Hostname results.
+	// We couldn't connect to any of those hostnames.
+	if len(checkedHostnames) == 0 {
+		result.Status = DomainCouldNotConnect
+		return result
+	}
+	for _, hostname := range checkedHostnames {
+		hostnameResult := result.HostnameResults[hostname]
+		// Any of the connected hostnames don't support STARTTLS.
+		if !hostnameResult.couldSTARTTLS() {
+			result.Status = DomainNoSTARTTLSFailure
+			return result
+		}
+		result.Status = DomainStatus(
+			SetStatus(CheckStatus(result.Status), CheckStatus(result.HostnameResults[hostname].Status)))
+	}
+	return result
+}

--- a/checker/hostname.go
+++ b/checker/hostname.go
@@ -1,0 +1,286 @@
+package checker
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/smtp"
+	"os"
+	"strings"
+	"time"
+)
+
+// HostnameResult wraps the results of a security check against a particular hostname.
+type HostnameResult struct {
+	Domain      string                 `json:"domain"`
+	Hostname    string                 `json:"hostname"`
+	MxHostnames []string               `json:"mx_hostnames,omitempty"`
+	Status      CheckStatus            `json:"status"`
+	Checks      map[string]CheckResult `json:"checks"`
+}
+
+// Returns result of specifiedcheck.
+// If called before that check occurs, returns false.
+func (h HostnameResult) checkSucceeded(checkName string) bool {
+	if result, ok := h.Checks[checkName]; ok {
+		return result.Status == Success
+	}
+	return false
+}
+
+func (h HostnameResult) couldConnect() bool {
+	return h.checkSucceeded("connectivity")
+}
+
+func (h HostnameResult) couldSTARTTLS() bool {
+	return h.checkSucceeded("starttls")
+}
+
+// Modelled after isWildcardMatch in Appendix B of the MTA-STS draft.
+// From draft v17:
+// Senders who are comparing a "suffix" MX pattern with a wildcard
+// identifier should thus strip the wildcard and ensure that the two
+// sides match label-by-label, until all labels of the shorter side
+// (if unequal length) are consumed.
+func wildcardMatch(hostname string, pattern string) bool {
+	if strings.HasPrefix(pattern, ".") {
+		parts := strings.SplitAfterN(hostname, ".", 2)
+		if len(parts) > 1 && parts[1] == pattern[1:] {
+			return true
+		}
+	}
+	return false
+}
+
+// Modelled after certMatches in Appendix B of the MTA-STS draft.
+func policyMatch(certName string, policyMx string) bool {
+	// Lowercase both names for comparison
+	certName = strings.ToLower(certName)
+	policyMx = strings.ToLower(policyMx)
+	if strings.HasPrefix(certName, "*") {
+		certName = certName[1:]
+		if !strings.HasPrefix(certName, ".") { // Invalid wildcard domain
+			return false
+		}
+	}
+	return certName == policyMx || wildcardMatch(certName, policyMx) ||
+		wildcardMatch(policyMx, certName)
+}
+
+// Checks certificate names against a list of expected MX patterns.
+// The expected MX patterns are in the format described by MTA-STS,
+// and validation is done according to this RFC as well.
+func hasValidName(certNames []string, mxs []string) bool {
+	for _, mx := range mxs {
+		for _, certName := range certNames {
+			if policyMatch(certName, mx) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Retrieves this machine's hostname, if specified.
+func getThisHostname() string {
+	hostname := os.Getenv("HOSTNAME")
+	if len(hostname) == 0 {
+		return "localhost"
+	}
+	return hostname
+}
+
+// Performs an SMTP dial with a short timeout.
+// https://github.com/golang/go/issues/16436
+func smtpDialWithTimeout(hostname string) (*smtp.Client, error) {
+	if _, _, err := net.SplitHostPort(hostname); err != nil {
+		hostname += ":25"
+	}
+	conn, err := net.DialTimeout("tcp", hostname, time.Second)
+	if err != nil {
+		return nil, err
+	}
+	client, err := smtp.NewClient(conn, hostname)
+	if err != nil {
+		return client, err
+	}
+	return client, client.Hello(getThisHostname())
+}
+
+// Simply tries to StartTLS with the server.
+func checkStartTLS(client *smtp.Client) CheckResult {
+	result := CheckResult{Name: "starttls"}
+	ok, _ := client.Extension("StartTLS")
+	if !ok {
+		return result.Failure("Server does not advertise support for STARTTLS.")
+	}
+	config := tls.Config{InsecureSkipVerify: true}
+	if err := client.StartTLS(&config); err != nil {
+		return result.Failure("Could not complete a TLS handshake.")
+	}
+	return result.Success()
+}
+
+// Retrieves valid names from certificate. If the certificate has
+// SAN, retrieves all SAN domains; otherwise returns a list containing only the CN.
+func getNamesFromCert(cert *x509.Certificate) []string {
+	if cert.DNSNames != nil && len(cert.DNSNames) > 0 {
+		return cert.DNSNames
+	}
+	return []string{cert.Subject.CommonName}
+}
+
+// If no MX matching policy was provided, then we'll default to accepting matches
+// based on the mail domain and the MX hostname.
+//
+// Returns a list containing the domain and hostname.
+func defaultValidMX(domain, hostname string) []string {
+	if strings.HasSuffix(hostname, ".") {
+		hostname = hostname[0 : len(hostname)-1]
+	}
+	return []string{domain, hostname}
+}
+
+// Validates that a certificate chain is valid for this system roots.
+func verifyCertChain(state tls.ConnectionState) error {
+	pool := x509.NewCertPool()
+	for _, peerCert := range state.PeerCertificates[1:] {
+		pool.AddCert(peerCert)
+	}
+	_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+		Roots:         certRoots,
+		Intermediates: pool,
+	})
+	return err
+}
+
+// certRoots is the certificate roots to use for verifying
+// a TLS certificate. It is nil by default so that the system
+// root certs are used.
+//
+// It is a global variable because it is used as a test hook.
+var certRoots *x509.CertPool
+
+// Checks that the certificate presented is valid for a particular hostname, unexpired,
+// and chains to a trusted root.
+func checkCert(client *smtp.Client, domain, hostname string, mxHostnames []string) CheckResult {
+	result := CheckResult{Name: "certificate"}
+	state, ok := client.TLSConnectionState()
+	if !ok {
+		return result.Error("TLS not initiated properly.")
+	}
+	cert := state.PeerCertificates[0]
+	if len(mxHostnames) == 0 {
+		mxHostnames = defaultValidMX(domain, hostname)
+	}
+	if !hasValidName(getNamesFromCert(cert), mxHostnames) {
+		result = result.Failure("Name in cert doesn't match any MX hostnames.")
+	}
+	err := verifyCertChain(state)
+	if err != nil {
+		return result.Failure("Certificate root is not trusted: %v", err)
+	}
+	return result.Success()
+}
+
+func tlsConfigForCipher(ciphers []uint16) tls.Config {
+	return tls.Config{
+		InsecureSkipVerify: true,
+		CipherSuites:       ciphers,
+	}
+}
+
+// Checks to see that insecure ciphers are disabled.
+func checkTLSCipher(hostname string) CheckResult {
+	result := CheckResult{Name: "cipher"}
+	badCiphers := []uint16{
+		tls.TLS_RSA_WITH_RC4_128_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA}
+	client, err := smtpDialWithTimeout(hostname)
+	if err != nil {
+		return result.Error("Could not establish connection with hostname %s", hostname)
+	}
+	defer client.Close()
+	config := tlsConfigForCipher(badCiphers)
+	err = client.StartTLS(&config)
+	if err == nil {
+		return result.Failure("Server should NOT be able to negotiate any ciphers with RC4.")
+	}
+	return result.Success()
+}
+
+func checkTLSVersion(client *smtp.Client, hostname string) CheckResult {
+	result := CheckResult{Name: "version"}
+
+	// Check the TLS version of the existing connection.
+	tlsConnectionState, ok := client.TLSConnectionState()
+	if !ok {
+		// We shouldn't end up here because we already checked that STARTTLS succeeded.
+		return result.Error("Could not check TLS connection version.")
+	}
+	if tlsConnectionState.Version < tls.VersionTLS12 {
+		result = result.Warning("Server should support TLSv1.2, but doesn't.")
+	}
+
+	// Attempt to connect with an old SSL version.
+	client, err := smtpDialWithTimeout(hostname)
+	if err != nil {
+		return result.Error("Could not establish connection: %v", err)
+	}
+	defer client.Close()
+	config := tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionSSL30,
+		MaxVersion:         tls.VersionSSL30,
+	}
+	err = client.StartTLS(&config)
+	if err == nil {
+		return result.Failure("Server should NOT support SSLv2/3, but does.")
+	}
+	return result.Success()
+}
+
+// Wrapping helper function to set the status of this hostname.
+func (h *HostnameResult) addCheck(checkResult CheckResult) {
+	h.Checks[checkResult.Name] = checkResult
+	// SetStatus sets HostnameResult's status to the most severe of any individual check
+	h.Status = SetStatus(h.Status, checkResult.Status)
+}
+
+// CheckHostname performs a series of checks against a hostname for an email domain.
+// `domain` is the mail domain that this server serves email for.
+// `hostname` is the hostname for this server.
+// `mxHostnames` is a list of MX patterns that `hostname` (and the associated TLS certificate)
+//     can be valid for. If this is nil, then defaults to [`domain`, `hostname`].
+func CheckHostname(domain string, hostname string, mxHostnames []string) HostnameResult {
+	result := HostnameResult{
+		Status:      Success,
+		Domain:      domain,
+		Hostname:    hostname,
+		MxHostnames: mxHostnames,
+		Checks:      make(map[string]CheckResult),
+	}
+
+	// Connect to the SMTP server and use that connection to perform as many checks as possible.
+	connectivityResult := CheckResult{Name: "connectivity"}
+	client, err := smtpDialWithTimeout(hostname)
+	if err != nil {
+		result.addCheck(connectivityResult.Error("Could not establish connection: %v", err))
+		return result
+	}
+	defer client.Close()
+	result.addCheck(connectivityResult.Success())
+
+	result.addCheck(checkStartTLS(client))
+	if result.Status != Success {
+		return result
+	}
+	result.addCheck(checkCert(client, domain, hostname, mxHostnames))
+	// result.addCheck(checkTLSCipher(hostname))
+
+	// Creates a new connection to check for SSLv2/3 support because we can't call starttls twice.
+	result.addCheck(checkTLSVersion(client, hostname))
+
+	return result
+}

--- a/checker/hostname_test.go
+++ b/checker/hostname_test.go
@@ -1,0 +1,287 @@
+package checker
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/mhale/smtpd"
+)
+
+func TestPolicyMatch(t *testing.T) {
+	var tests = []struct {
+		certName string
+		policyMX string
+		want     bool
+	}{
+		// Equal matches
+		{"example.com", "example.com", true},
+		{"mx.example.com", "mx.example.com", true},
+
+		// Not equal matches
+		{"different.org", "example.com", false},
+		{"not.example.com", "example.com", false},
+
+		// base domain shouldn't match wildcard
+		{"example.com", ".example.com", false},
+		{"*.example.com", "example.com", false},
+
+		// Invalid wildcard shouldn't match.
+		{"*mx.example.com", "mx.example.com", false},
+
+		// Single-level subdomain match for policy suffix.
+		{"mx.example.com", ".example.com", true},
+		{"*.example.com", ".example.com", true},
+
+		// No multi-level subdomain matching for policy suffix.
+		{"mx.mx.example.com", ".example.com", false},
+		{"*.mx.example.com", ".example.com", false},
+
+		// Role reversal also works.
+		{"*.example.com", "mx.example.com", true},
+		{"*.example.com", "mx.mx.example.com", false},
+		{"*.example.com", ".mx.example.com", false},
+	}
+
+	for _, test := range tests {
+		if got := policyMatch(test.certName, test.policyMX); got != test.want {
+			t.Errorf("policyMatch(%q, %q) = %v", test.certName, test.policyMX, got)
+		}
+	}
+}
+
+func TestNoConnection(t *testing.T) {
+	result := CheckHostname("", "example.com", nil)
+
+	expected := HostnameResult{
+		Status: 3,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 3, nil},
+		},
+	}
+	compareStatuses(t, expected, result)
+}
+
+func TestNoTLS(t *testing.T) {
+	ln := smtpListenAndServe(t, &tls.Config{})
+	defer ln.Close()
+
+	result := CheckHostname("", ln.Addr().String(), nil)
+
+	expected := HostnameResult{
+		Status: 2,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 2, nil},
+		},
+	}
+	compareStatuses(t, expected, result)
+}
+
+func TestSelfSigned(t *testing.T) {
+	cert, err := tls.X509KeyPair([]byte(certString), []byte(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln := smtpListenAndServe(t, &tls.Config{Certificates: []tls.Certificate{cert}})
+	defer ln.Close()
+
+	result := CheckHostname("", ln.Addr().String(), nil)
+
+	expected := HostnameResult{
+		Status: 2,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 0, nil},
+			"certificate":  {"certificate", 2, nil},
+			"version":      {"version", 0, nil},
+		},
+	}
+	compareStatuses(t, expected, result)
+}
+
+func TestNoTLS12(t *testing.T) {
+	cert, err := tls.X509KeyPair([]byte(certString), []byte(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln := smtpListenAndServe(t, &tls.Config{
+		MinVersion:   tls.VersionTLS11,
+		MaxVersion:   tls.VersionTLS11,
+		Certificates: []tls.Certificate{cert},
+	})
+	defer ln.Close()
+
+	result := CheckHostname("", ln.Addr().String(), nil)
+
+	expected := HostnameResult{
+		Status: 2,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 0, nil},
+			"certificate":  {"certificate", 2, nil},
+			"version":      {"version", 1, nil},
+		},
+	}
+	compareStatuses(t, expected, result)
+}
+
+func TestSuccessWithFakeCA(t *testing.T) {
+	cert, err := tls.X509KeyPair([]byte(certString), []byte(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln := smtpListenAndServe(t, &tls.Config{Certificates: []tls.Certificate{cert}})
+	defer ln.Close()
+
+	certRoots, _ = x509.SystemCertPool()
+	certRoots.AppendCertsFromPEM([]byte(certString))
+	defer func() {
+		certRoots = nil
+	}()
+
+	result := CheckHostname("", ln.Addr().String(), nil)
+	expected := HostnameResult{
+		Status: 0,
+		Checks: map[string]CheckResult{
+			"connectivity": {"connectivity", 0, nil},
+			"starttls":     {"starttls", 0, nil},
+			"certificate":  {"certificate", 0, nil},
+			"version":      {"version", 0, nil},
+		},
+	}
+	compareStatuses(t, expected, result)
+}
+
+func TestAdvertisedCiphers(t *testing.T) {
+	cert, err := tls.X509KeyPair([]byte(certString), []byte(key))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cipherSuites []uint16
+	// GetConfigForClient is a callback that lets us alter the TLSConfig
+	// based on the client hello. Here we just use it to check which ciphers
+	// are advertised by the client.
+	//
+	// Alternatively, we could use the CipherSuites attribute to attempt a
+	// separate connection with each cipher.
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+			if len(cipherSuites) == 0 {
+				// Throw out the second connection to the mailserver
+				// where we intentionally advertised insecure ciphers.
+				cipherSuites = info.CipherSuites
+			}
+			return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
+		},
+	}
+
+	ln := smtpListenAndServe(t, tlsConfig)
+	defer ln.Close()
+	CheckHostname("", ln.Addr().String(), nil)
+
+	// Partial list of ciphers we want to support
+	expectedCipherSuites := []struct {
+		val  uint16
+		desc string
+	}{
+		{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+		{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"},
+	}
+	for _, expected := range expectedCipherSuites {
+		if !containsCipherSuite(cipherSuites, expected.val) {
+			t.Errorf("expected check to advertise ciphersuite %s", expected.desc)
+		}
+	}
+}
+
+func containsCipherSuite(result []uint16, want uint16) bool {
+	for _, candidate := range result {
+		if want == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+// compareStatuses compares the status for the HostnameResult and each Check with a desired value
+func compareStatuses(t *testing.T, expected HostnameResult, result HostnameResult) {
+	if result.Status != expected.Status {
+		t.Errorf("hostname status = %d, want %d", result.Status, expected.Status)
+	}
+
+	if len(result.Checks) > len(expected.Checks) {
+		t.Errorf("result contains too many checks\n expected %v\n want %v", result.Checks, expected.Checks)
+	}
+
+	for _, c := range expected.Checks {
+		if got := result.Checks[c.Name].Status; got != c.Status {
+			t.Errorf("%s status = %d, want %d", c.Name, got, c.Status)
+		}
+	}
+}
+
+// smtpListenAndServe creates a test smtp server to run checks on.
+// We use this rather than smtpd.ListenAndServe so that we can use net.Listen
+// to assign a random available port.
+func smtpListenAndServe(t *testing.T, tlsConfig *tls.Config) net.Listener {
+	srv := &smtpd.Server{
+		Handler:  noopHandler,
+		Hostname: "example.com",
+	}
+	srv.TLSConfig = tlsConfig
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		if err := srv.Serve(ln); err != nil {
+			if strings.Contains(err.Error(), "closed") {
+				return
+			}
+			t.Fatal(err)
+		}
+	}()
+
+	return ln
+}
+
+func noopHandler(_ net.Addr, _ string, _ []string, _ []byte) {}
+
+// Commands to generate the self-signed certificate below:
+//	openssl req -new -key server.key -out server.csr
+//	openssl x509 -req -in server.csr -signkey server.key -out server.crt
+
+const certString = `-----BEGIN CERTIFICATE-----
+MIIBkDCB+gIJAP/G75+MvzSQMA0GCSqGSIb3DQEBBQUAMA0xCzAJBgNVBAYTAlVT
+MB4XDTE4MDcyNjE2NDM0MloXDTE4MDgyNTE2NDM0MlowDTELMAkGA1UEBhMCVVMw
+gZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBALsGFO2tmSAPtDR8YccGXhNGsQU7
+YqY33cxVl1OhvZLefBawVSho/0nHhaxDQX4zA/acpNLnYu9MKo/IP1UWn1dLnYy2
+rpzKUr5ROQoBCdJW7XiDl1LSABsz3XjPE7U0Wn/0LiIKLSpopbM8IYsIgSiqRvv4
+eVhB6QGQkdHdPOrdAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAIbh+2deYaUdQ2w9Z
+h/HDykuWhf452E/QGx2ltiEB4hj/ggxn5Hho0W5+nAjc3HRa16B0UvmyBSxSFG47
+8E0+wATR37GHenDLtTgIAEv3Ax7ojTsSYI7ssm+USkhd8GfeCzNWYGO4KAUuWS1r
+CFPY0q3dB4ltPdEVfgGNZYTRqIU=
+-----END CERTIFICATE-----`
+
+const key = `-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQC7BhTtrZkgD7Q0fGHHBl4TRrEFO2KmN93MVZdTob2S3nwWsFUo
+aP9Jx4WsQ0F+MwP2nKTS52LvTCqPyD9VFp9XS52Mtq6cylK+UTkKAQnSVu14g5dS
+0gAbM914zxO1NFp/9C4iCi0qaKWzPCGLCIEoqkb7+HlYQekBkJHR3Tzq3QIDAQAB
+AoGBALL2RuCI1ZYQcOgofYftV+gqJQpUoTldDCiTXpLwmm8H5sXvRg29K0x2WDtW
+wDz6pDg//Ji0Qb+qqq+bdr79PsquUon6G+t9LWFQ6F1qD7JRssBr5FPAfWFij2pm
+zH61dX/j/kas67W+23H4k0Rc3oExaPF4gecc/EJaQ4Wc5EohAkEA6GaMhlwsONhv
+TbW3FIOm54obvLhS0XDrdig8CIl7+x6KSBsHBmLv+MDh/DRywwv5sOR6Sg6HGMAc
+4pNsk6UOXwJBAM4D7HHfqMyuiKDIiAwdjPn/Ux2nlQe05d7iai0nSEVEfneaGX/g
+r4C1Gg8VDA6U94XE/S9d60IpUg4DwH9W2EMCQCufxFUcTDjHd+0wZRN2uwfPhvFf
+8DvcZHajitFXbWxwCSkL2b+7JqydGE6NUdWHE/G+ka4BGB7vQPzPC5yTaSUCQAn3
+Ap7XdLDB2HX+fSYo38LP6NNMYdcHlv7a8MvSVJqVH5DlcUpQMe0F1YbZO8YQypA7
+4QtDfberi/6Fi/Ac4UUCQQDHf89gtZYZKfeTBMRwaer7yG/UovX2AJSkCB34BGxn
+gIxzlen/RRmXtBGCR5G24n08/2AJaMeI/8sJWM8or9cs
+-----END RSA PRIVATE KEY-----`


### PR DESCRIPTION
Basically following [these instructions](https://saintgimp.org/2013/01/22/merging-two-git-repositories-into-one-repository-without-losing-file-history/) - no fancy subtrees or submodules, I just merged 'em :metal: 

IMO this resolves #75 

Will follow up with a PR that renames starttls-scanner to starttls-backend once this is merged.

Interestingly, the checker failed to advertise the ciphersuites listed in [checker issue 30](https://github.com/EFForg/starttls-check/issues/30) in https://travis-ci.com/EFForg/starttls-scanner/builds/81079716. I bumped the Go version to 1.10 and it passes. Will create a ticket to bump to the Go version in the Dockerfile.

When this is ready for merge, please merge this one without squashing so we can keep that sweet commit history :)